### PR TITLE
Add wipefs -a to clear out partition tables

### DIFF
--- a/lvm_create
+++ b/lvm_create
@@ -106,6 +106,7 @@ seper=""
 for i in $devices_to_use; do
 	lv_disks=${i}${seper}${lv_disks}
 	size=`fdisk -l $i | grep bytes | grep  Disk | cut -d' ' -f 5`
+	wipefs -a ${i}
 	gb=`echo "$size/(1024*1024*1024)" | bc`
 	let "lv_total_size=$lv_total_size+$gb"
 	let "lv_disk_count=$lv_disk_count+1"


### PR DESCRIPTION
If there is a partition table on the drive, pvcreate will fail and then everything after gets very confused.  Use 'wipefs -a' to wipeout any existing partitions.